### PR TITLE
ci: run the tests instead of the Code Climate action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,11 +23,5 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true
-    - name: Test & publish code coverage
-      uses: paambaati/codeclimate-action@v3.2.0
-      env:
-        CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
-      with:
-        coverageCommand: bundle exec rake
-        coverageLocations: ${{ github.workspace }}/coverage/coverage.json:simplecov
-        debug: true
+    - name: Run the tests
+      run: bundle exec rake


### PR DESCRIPTION
paambaati/codeclimate-action fails at "CC Reporter checksum does not match" before it runs its coverageCommand. No test in this repository has run on any pull request since the reporter binary changed, and the required check `Ruby 3.1.2` reports a failure that says nothing about the code.

- Moves `bundle exec rake` into a step of its own, because the action carried the test command.
- Drops coverage reporting to Code Climate, which was already producing nothing.

The `CC_TEST_REPORTER_ID` secret is left in place. Merging this unblocks svyatov/card_dealer#27.